### PR TITLE
perf: cache NumberFormat before expanding options

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "homepage": "https://github.com/exodusmovement/format-num#readme",
   "dependencies": {
-    "parse-num": "^1.0.0",
-    "lodash": "^4.17.11"
+    "parse-num": "^1.0.0"
   },
   "devDependencies": {
     "ava": "0.22.x",


### PR DESCRIPTION
Options expansion was slow

This gives additional 2.7x speedup compared to #8 

Also, we don't need lodash